### PR TITLE
fix: allow export of ChatGPTs bots

### DIFF
--- a/src/services/checker/allowedDomains.json
+++ b/src/services/checker/allowedDomains.json
@@ -12,6 +12,7 @@
     "PerplexityPages": "www.perplexity.ai/page",
     "MaxAIGoogle": "www.google.com/search",
     "ChatGPT": "chatgpt.com/c",
-    "ChatGPTShare": "chatgpt.com/share"
+    "ChatGPTShare": "chatgpt.com/share",
+    "ChatGPTBots": "chatgpt.com/g"
   }
 }

--- a/src/services/export/extractor/extractPage.ts
+++ b/src/services/export/extractor/extractPage.ts
@@ -27,6 +27,7 @@ export async function extractPage(domain: { name: any; url?: any; }) {
       break;
     case "ChatGPT":
     case "ChatGPTShare":
+    case "ChatGPTBots":
       module = require("./domains/ChatGPT");
       json = require("./domains/ChatGPT.json");
       break;


### PR DESCRIPTION
Allow export of `chatgpt.com/g/<bot-id>/c/<conv-id>`